### PR TITLE
Matchers should be the first argument to matches?

### DIFF
--- a/src/shrubbery/core.clj
+++ b/src/shrubbery/core.clj
@@ -25,9 +25,9 @@
         (re-seq value)
         (first)
         (boolean)))
-  clojure.lang.ArraySeq
+  clojure.lang.IPersistentVector
   (matches? [matcher value]
-    (->> (map matches? value matcher)
+    (->> (map matches? matcher value)
          (every? identity)))
   java.lang.Object
   (matches? [matcher value]
@@ -48,7 +48,7 @@
   ([spy method args]
   (->>
      (get (calls spy) method)
-     (filter #(matches? % args))
+     (filter #(matches? args %))
      (count))))
 
 (defmacro received?


### PR DESCRIPTION
Make `call-count` pass the matcher vec as the first argument to `matches?`.
This means the first argument becomes a IPersistentVector instead
of an ArraySeq. Then matcher is actually the vector of matchers,
so when traversal happens walk it as the first list.

This is consistent with the arguments for other matcher implementations and
the protocol's argument names.