### PR TITLE
Allow namespacing through vars

### DIFF
--- a/src/shrubbery/clojure/test.clj
+++ b/src/shrubbery/clojure/test.clj
@@ -5,7 +5,7 @@
 
 (defmethod assert-expr 'received? [msg form]
   `(let [spy# ~(nth form 1)
-         method# ~(-> (nth form 2) resolve)
+         method# ~(-> (nth form 2))
          args# ~(some-> form (nth 3 nil))]
      (let [count# (apply call-count spy# (remove nil? [method# args#]))
            result# (= count# 1)]

--- a/src/shrubbery/clojure/test.clj
+++ b/src/shrubbery/clojure/test.clj
@@ -5,11 +5,11 @@
 
 (defmethod assert-expr 'received? [msg form]
   `(let [spy# ~(nth form 1)
-         method# ~(-> (nth form 2) (str) (keyword))
+         method# ~(-> (nth form 2) resolve)
          args# ~(some-> form (nth 3 nil))]
      (let [count# (apply call-count spy# (remove nil? [method# args#]))
            result# (= count# 1)]
        (if result#
-         (do-report {:type :pass :message ~msg :expected '~form :actual (method# (calls spy#))})
-         (do-report {:type :fail :message ~msg :expected '~form :actual (format "received %s times; other calls: %s" count# (or (method# (calls spy#)) []))})
+         (do-report {:type :pass :message ~msg :expected '~form :actual (get (calls spy#) method#)})
+         (do-report {:type :fail :message ~msg :expected '~form :actual (format "received %s times; other calls: %s" count# (or (get (calls spy#) method#) []))})
        ))))

--- a/src/shrubbery/core.clj
+++ b/src/shrubbery/core.clj
@@ -25,9 +25,9 @@
         (re-seq value)
         (first)
         (boolean)))
-  clojure.lang.ArraySeq
+  clojure.lang.IPersistentVector
   (matches? [matcher value]
-    (->> (map matches? value matcher)
+    (->> (map matches? matcher value)
          (every? identity)))
   java.lang.Object
   (matches? [matcher value]
@@ -48,7 +48,7 @@
   ([spy method args]
   (->>
      (get (calls spy) method)
-     (filter #(matches? % args))
+     (filter #(matches? args %))
      (count))))
 
 (defmacro received?

--- a/src/shrubbery/core.clj
+++ b/src/shrubbery/core.clj
@@ -40,22 +40,22 @@
     (matches? [_ _] true)))
 
 (defn call-count
-  "Given a spy, a keyword method name, and an optional vector of args, return the number of times the spy received
+  "Given a spy, a var, and an optional vector of args, return the number of times the spy received
   the method. If given args, filters the list of calls by matching the given args. Matched args may implement the `Matcher`
   protocol; the default implementation for `Object` is `=`."
-  ([spy method]
-   (-> (calls spy) (get method) (count)))
-  ([spy method args]
-  (->>
-     (get (calls spy) method)
+  ([spy var]
+   (-> (calls spy) (get var) (count)))
+  ([spy var args]
+   (->>
+     (get (calls spy) var)
      (filter #(matches? args %))
      (count))))
 
 (defmacro received?
   ([spy method]
-   `(>= (call-count ~spy ~(-> method str keyword)) 1))
+   `(>= (call-count ~spy ~(->> method resolve)) 1))
   ([spy method args]
-   `(>= (call-count ~spy ~(-> method str keyword) ~args) 1)))
+   `(>= (call-count ~spy ~(->> method resolve) ~args) 1)))
 
 (defn- fn-sigs [proto]
   (-> proto resolve var-get :sigs))
@@ -63,12 +63,13 @@
 (defn proto-fn-with-proxy
   "Given a protocol implementation, a function with side effects, and a protcol function signature, return
   a syntax-quoted protocol method implementation that calls the function, then proxies to the given implementation."
-  [impl f [m sig]]
+  [impl f ns [m sig]]
   (let [f-sym (-> m name symbol)
+        var (-> m name (->> (symbol ns)) resolve)
         args (-> sig :arglists first)]
-    `(~f-sym ~args                   ; (foo [this a b]
-       (~f ~m ~@args)                ;   ((fn [method this a b] ...) :foo this a b)
-       (~f-sym ~impl ~@(rest args))) ;   (foo proto-impl a b))
+    `(~f-sym ~args                                          ; (foo [this a b]
+       (~f (resolve (symbol ~ns (name ~m))) ~@args)         ;   ((fn [method this a b] ...) :foo this a b)
+       (~(symbol ns (name f-sym)) ~impl ~@(rest args)))                        ;   (foo proto-impl a b))
     ))
 
 (defn proto-fn-with-impl
@@ -77,9 +78,12 @@
   [f [m sig]]
   (let [f-sym (-> m name symbol)
         args (-> sig :arglists first)]
-    `(~f-sym ~args                   ; (foo [this a b]
-       (~f ~@args))               ;   ((fn [method this a b] ...) :foo this a b)
+    `(~f-sym ~args                                          ; (foo [this a b]
+       (~f ~@args))                                         ;   ((fn [method this a b] ...) :foo this a b)
     ))
+
+(defn namespace-str [proto]
+  (-> proto resolve meta :ns str))
 
 (defmacro spy
   "Given a protocol and an implementation of that protocol, returns a new implementation of that protocol that counts
@@ -87,8 +91,8 @@
   counts. Each method is proxied to the given impl after capture."
   [proto proxy]
   (let [atom-sym (gensym "counts")
-        recorder `(fn [m# & args#] (swap! ~atom-sym assoc m# (conj (-> ~atom-sym deref m#) (rest args#))))
-        mimpls (map (partial proto-fn-with-proxy proxy recorder) (fn-sigs proto))]
+        recorder `(fn [m# & args#] (swap! ~atom-sym update-in [m#] conj (rest args#)))
+        mimpls (map (partial proto-fn-with-proxy proxy recorder (namespace-str proto)) (fn-sigs proto))]
     `(let [~atom-sym (atom {})]
        (reify
          ~proto
@@ -107,10 +111,13 @@
   "Given a protocol and a hashmap of function implementations, returns a new implementation of that protocol with those
   implementations. If no function implementation is given for a method, that method will return `nil` when called."
   ([proto]
-  `(stub ~proto {}))
+   `(stub ~proto {}))
   ([proto impls]
-   (let [sigs (fn-sigs proto)
-         fns (map (fn [[m _]] (wrap-fn impls m)) sigs)
+   (let [impls (into {} (for [[k v] impls] [(resolve (symbol (namespace k)
+                                                             (name k))) v]))
+         sigs (fn-sigs proto)
+         fns (map (fn [[m _]] (wrap-fn impls (resolve (symbol (namespace-str proto)
+                                                              (name m))))) sigs)
          mimpls (map proto-fn-with-impl fns sigs)]
      `(reify
         ~proto

--- a/src/shrubbery/core.clj
+++ b/src/shrubbery/core.clj
@@ -53,9 +53,9 @@
 
 (defmacro received?
   ([spy method]
-   `(>= (call-count ~spy ~(->> method resolve)) 1))
+   `(>= (call-count ~spy ~method) 1))
   ([spy method args]
-   `(>= (call-count ~spy ~(->> method resolve) ~args) 1)))
+   `(>= (call-count ~spy ~method ~args) 1)))
 
 (defn- fn-sigs [proto]
   (-> proto resolve var-get :sigs))
@@ -67,7 +67,7 @@
   (let [f-sym (-> m name symbol)
         args (-> sig :arglists first)]
     `(~f-sym ~args                                          ; (foo [this a b]
-       ~(apply f (resolve (symbol ns (name m))) args)         ;   ((fn [method this a b] ...) :foo this a b)
+       ~(apply f (symbol ns (name m)) args)         ;   ((fn [method this a b] ...) :foo this a b)
        (~(symbol ns (name f-sym)) ~impl ~@(rest args)))     ;   (foo proto-impl a b))
     ))
 

--- a/test/shrubbery/core_test.clj
+++ b/test/shrubbery/core_test.clj
@@ -116,14 +116,14 @@
 
   (testing "with a let-binding that resolves to a function"
     (let [some-fn (fn [& args] :foo)
-          subject (stub AProtocol {:foo some-fn :bar some-fn :baz some-fn})]
+          subject (stub AProtocol {foo some-fn bar some-fn baz some-fn})]
       (is (= :foo (foo subject)))
       (is (= :foo (bar subject :hello)))
       (is (= :foo (baz subject :hello :world)))
       ))
 
   (testing "with an immediate simple primitive"
-    (let [subject (stub AProtocol {:foo 1 :bar "two" :baz 'three})]
+    (let [subject (stub AProtocol {foo 1 bar "two" baz 'three})]
       (is (= 1 (foo subject)))
       (is (= "two" (bar subject :hello)))
       (is (= 'three (baz subject :hello :world)))
@@ -131,7 +131,7 @@
 
   (testing "with a let-binding that resolves to a primitive"
     (let [some-o "some object"
-          subject (stub AProtocol {:foo some-o :bar some-o :baz some-o})]
+          subject (stub AProtocol {foo some-o bar some-o baz some-o})]
       (is (= "some object" (foo subject)))
       (is (= "some object" (bar subject :hello)))
       (is (= "some object" (baz subject :hello :world)))
@@ -151,7 +151,7 @@
       ))
 
   (testing "with a basic implementation"
-    (let [subject (mock AProtocol {:bar (fn [this that] that)})]
+    (let [subject (mock AProtocol {bar (fn [this that] that)})]
       (is (= "wow" (bar subject "wow")))
       (is (received? subject bar))
       (is (not (received? subject foo)))
@@ -187,11 +187,11 @@
       ))
 
   (testing "with a basic implementation"
-    (let [subject (mock p/NamespacedProto {:p/zzz-arged (fn [this that] that)})]
+    (let [subject (mock p/NamespacedProto {p/zzz-arged (fn [this that] that)})]
       (is (= "wow" (p/zzz-arged subject "wow")))
       (is (received? subject p/zzz-arged))
       (is (not (received? subject p/zzz)))
-      (is (received? subject p/zzz-arged ["wow"]))
+      (is (received? subject shrubbery.proto-helper/zzz-arged ["wow"]))
       (is (not (received? subject p/zzz-arged ["woo"])))
       ))
   )

--- a/test/shrubbery/core_test.clj
+++ b/test/shrubbery/core_test.clj
@@ -18,71 +18,71 @@
 (deftest test-spy
   (testing "a simple call counter"
     (let [subject (spy AProtocol proto)]
-      (is (= 0 (call-count subject #'foo)))
+      (is (= 0 (call-count subject foo)))
       (is (= :hello-foo (foo subject)))
-      (is (= 1 (call-count subject #'foo)))
+      (is (= 1 (call-count subject foo)))
       (is (= :hello-foo (foo subject)))
-      (is (= 2 (call-count subject #'foo)))
+      (is (= 2 (call-count subject foo)))
       ))
 
   (testing "a call counter with simple argument equality"
     (let [subject (spy AProtocol proto)]
-      (is (= 0 (call-count subject #'bar)))
+      (is (= 0 (call-count subject bar)))
 
       (bar subject "yes")
-      (is (= 0 (call-count subject #'bar ["no"])))
-      (is (= 1 (call-count subject #'bar ["yes"])))
+      (is (= 0 (call-count subject bar ["no"])))
+      (is (= 1 (call-count subject bar ["yes"])))
 
       (bar subject :symbol)
-      (is (= 1 (call-count subject #'bar [:symbol])))
+      (is (= 1 (call-count subject bar [:symbol])))
       ))
 
   (testing "a call counter with regexp matching"
     (let [subject (spy AProtocol proto)]
-      (is (= 0 (call-count subject #'bar)))
+      (is (= 0 (call-count subject bar)))
 
       (bar subject "yes")
-      (is (= 0 (call-count subject #'bar ["no"])))
-      (is (= 0 (call-count subject #'bar [#"no"])))
-      (is (= 1 (call-count subject #'bar [#"yes"])))
-      (is (= 1 (call-count subject #'bar [#"y.."])))
+      (is (= 0 (call-count subject bar ["no"])))
+      (is (= 0 (call-count subject bar [#"no"])))
+      (is (= 1 (call-count subject bar [#"yes"])))
+      (is (= 1 (call-count subject bar [#"y.."])))
 
       (bar subject "yess")
-      (is (= 1 (call-count subject #'bar ["yes"])))
-      (is (= 1 (call-count subject #'bar [#"yess"])))
-      (is (= 2 (call-count subject #'bar [#"yes"])))
-      (is (= 2 (call-count subject #'bar [#"y*"])))
+      (is (= 1 (call-count subject bar ["yes"])))
+      (is (= 1 (call-count subject bar [#"yess"])))
+      (is (= 2 (call-count subject bar [#"yes"])))
+      (is (= 2 (call-count subject bar [#"y*"])))
       ))
 
   (testing "a call counter that matches anything"
     (let [subject (spy AProtocol proto)]
-      (is (= 0 (call-count subject #'bar)))
+      (is (= 0 (call-count subject bar)))
 
       (bar subject "wow such matching")
-      (is (= 1 (call-count subject #'bar)))
-      (is (= 1 (call-count subject #'bar [anything])))
+      (is (= 1 (call-count subject bar)))
+      (is (= 1 (call-count subject bar [anything])))
       ))
 
   (testing "a call counter that matches multiple arguments"
     (let [subject (spy AProtocol proto)]
-      (is (= 0 (call-count subject #'baz)))
+      (is (= 0 (call-count subject baz)))
 
       (baz subject "hello" "world")
-      (is (= 1 (call-count subject #'baz ["hello" "world"])))
-      (is (= 0 (call-count subject #'baz ["hello" "w"])))
-      (is (= 1 (call-count subject #'baz ["hello" anything])))
+      (is (= 1 (call-count subject baz ["hello" "world"])))
+      (is (= 0 (call-count subject baz ["hello" "w"])))
+      (is (= 1 (call-count subject baz ["hello" anything])))
       ))
 
   (testing "a call counter with arbitrary matching"
     (let [subject (spy AProtocol proto)]
-      (is (= 0 (call-count subject #'baz)))
+      (is (= 0 (call-count subject baz)))
 
       (bar subject 2)
-      (is (= 1 (call-count subject #'bar [#(> % 1)])))
-      (is (= 0 (call-count subject #'bar [#(> % 2)])))
+      (is (= 1 (call-count subject bar [#(> % 1)])))
+      (is (= 0 (call-count subject bar [#(> % 2)])))
       (bar subject 1)
-      (is (= 2 (call-count subject #'bar [#(> % 0)])))
-      (is (= 1 (call-count subject #'bar [#(> % 1)])))
+      (is (= 2 (call-count subject bar [#(> % 0)])))
+      (is (= 1 (call-count subject bar [#(> % 1)])))
       ))
   )
 
@@ -165,11 +165,11 @@
     (let [subject (spy p/NamespacedProto
                        (reify p/NamespacedProto
                          (zzz [_])))]
-      (is (= 0 (call-count subject #'p/zzz)))
+      (is (= 0 (call-count subject p/zzz)))
       (p/zzz subject)
-      (is (= 1 (call-count subject #'p/zzz)))
+      (is (= 1 (call-count subject p/zzz)))
       (p/zzz subject)
-      (is (= 2 (call-count subject #'p/zzz)))
+      (is (= 2 (call-count subject p/zzz)))
       ))
   )
 

--- a/test/shrubbery/proto_helper.clj
+++ b/test/shrubbery/proto_helper.clj
@@ -1,0 +1,5 @@
+(ns shrubbery.proto-helper)
+
+(defprotocol NamespacedProto
+  (zzz [t])
+  (zzz-arged [t arg]))


### PR DESCRIPTION
While trying to use namespaced protocols I ran into macroexpansion issues.  The protocol functions were being used as non-namespaced symbols and where then unable to be resolved when the file was loaded.

I'm happy to use this as a reference patch for discussion. While some of the API changes seem necessary or consistent, I could see them as being too far for a random PR from the internet.

----
This is an attempt to allow namespacing. When adding namespacing, some issues can come up when using aliases. If keywords are used directly there is no good way to determine `:p/zzz` is the same as `:some.ns.proto/zzz`. However, if things are resolved to the underlining `Var`s they are suppose to represent, then aliasing is removed.  Due to this issue, it does not seem possible to keep a backwards compatible api that uses keywords. This PR makes some changes to using symbols and vars as the api.

This PR changes:

1. Use symbols instead of keywords in `Stub` implementations.  This is consistent with the use of symbols in `received`.
2. When delegating methods for a `Stub`
  1. Resolve the symbols in the stub map
  2. Use the protocol's `Var` to determine namespace
  3. Use that namespace to resolve each functions's `Var` based on its keyword in the protocol's `:sig`
3. When proxying methods for a `Spy`
  1. Find each protocol function's `Var`
  2. Use the `Var` to keep track of counts (avoids aliasing problems)
  4. Output code that uses the namespaced version of the function call to proxy forward
3. Unfortunately require `call-count` to use a `Var` instead of a keyword (if `call-count` was a macro a symbol would be consistent).