### PR TITLE
Adds a stub syntax for throwables

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,20 @@ Once defined, stubs cannot currently be altered, though they may be introspected
 
 ```clojure
 (defprotocol DbQueryClient
-  (select [client sql] "Returns a list of database records matching the given query."))
+  (select [client sql] "Returns a list of database records matching the given query.")
+  (insert [client sql] "Inserts a record using the given SQL."))
+
+(def database-stub
+  (stub DbQueryClient
+    {:select [{:name "Guybrush"}]
+     :insert (throws RuntimeException "Insert not supported"})
 
 (defn find-user [client id]
   (select client (str "select * from users where id = " id)))
 
 (deftest test-find-user
   (is (nil? (find-user (stub DbQueryClient) 42)))
-  (is (= "Guybrush" (-> (stub DbQueryClient {:select [{:name "Guybrush"}]}) (find-user 42) (first) (:name)))))
+  (is (= "Guybrush" (-> database-stub (find-user 42) (first) (:name)))))
 ```
 
 ### Spies
@@ -142,8 +148,7 @@ call `stub` with the given arguments, then wrap that stub in a `spy`.
     (is (not (received? subject select)))
     (is (= {:id 1} (find-user subject 42)))
     (is (received? subject select))
-    (is (received? subject select [42]))
-    ))
+    (is (received? subject select [42]))))
 ```
 
 ### Matchers

--- a/src/shrubbery/core.clj
+++ b/src/shrubbery/core.clj
@@ -108,7 +108,6 @@
   java.lang.Object
   (reify-syntax-for-stub [thing] thing))
 
-
 (defn- stub-fn [proto impl-hash [m sig]]
   (let [args              (-> sig :arglists first)
         f-sym             (-> sig :name)
@@ -203,6 +202,12 @@
       (apply mock new-all-stubs)
       (apply stub new-all-stubs))))
 
+(defn throws
+  "Given a class and a list of constructor args, returns an object that, when used as part of a [[stub]] construct, will
+  create and then throw a Throwable of the given type, constructed with the given args."
+  [^Class throwable-class & args]
+  (reify Stubbable
+    (reify-syntax-for-stub [_] `(throw (new ~throwable-class ~@args)))))
 
 (extend-protocol Matcher
   clojure.lang.AFunction


### PR DESCRIPTION
This adds a new method, `throws`, that accepts a subclass of `Throwable` and zero or more constructor arguments, and returns an object suitable for passing to `stub`. When the stubbed function is invoked, a new Throwable of the given class will be constructed with the given arguments and thrown, as so:

```clojure
(defprotocol AProtocol
  (explode [t]))

(let [stub-that-throws (stub AProtocol {:explode (throws RuntimeException "boom")})]
  (explode stub-that-throws)) ;; thrown: RuntimeException boom
```