### PR TITLE
Raise exception on bad call-count args. Fixes #11.

### DIFF
--- a/src/shrubbery/core.clj
+++ b/src/shrubbery/core.clj
@@ -172,6 +172,7 @@
   (spy
     (apply stub protos-and-impls)))
 
+
 (defn call-count
   "Given a [[spy]], a var, and an optional vector of args, return the number of times the spy received
   the method. If given args, filters the list of calls by matching the given args. Matched args may implement the
@@ -179,6 +180,8 @@
   ([aspy avar]
    (-> (calls aspy) (get avar) (count)))
   ([aspy avar args]
+   (when-not (vector? args)
+     (throw (IllegalArgumentException. "Please supply a vector of arguments to check against this spy.")))
    (->>
      (get (calls aspy) avar)
      (filter #(matches? args %))

--- a/test/shrubbery/core_test.clj
+++ b/test/shrubbery/core_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [shrubbery.core :refer :all]
             [shrubbery.clojure.test :refer :all]
-            [shrubbery.is.a.great.library.with.lots.of.super-obvious.use-cases :as use-cases]))
+            [shrubbery.is.a.great.library.with.lots.of.super-obvious.use-cases :as use-cases])
+  (:import (java.util ArrayList)))
 
 (defprotocol AProtocol
   (foo  [this])
@@ -54,7 +55,10 @@
       (is (= 1 (call-count subject bar ["yes"])))
 
       (bar subject :symbol)
-      (is (= 1 (call-count subject bar [:symbol])))))
+      (is (= 1 (call-count subject bar [:symbol])))
+
+      (bar subject (doto (ArrayList.) (.add 1)))
+      (is (= 1 (call-count subject bar [(doto (ArrayList.) (.add 1))])))))
 
   (testing "a call counter with regexp matching"
     (let [subject (spy proto)]
@@ -130,7 +134,14 @@
 
       (is (= 0 (call-count subject baz)))
       (is (= :baz (baz subject nil nil)))
-      (is (= 1 (call-count subject baz))))))
+      (is (= 1 (call-count subject baz)))))
+
+  (testing "a call counter with a single supplied argument that isn't a vector"
+    (let [subject (spy proto)]
+      (is (thrown? IllegalArgumentException
+                   (call-count subject bar "hello")))
+      (is (thrown? IllegalArgumentException
+                   (call-count subject bar :foo))))))
 
 (deftest test-received?
   (testing "a simple received? call"


### PR DESCRIPTION
When `call-count` or `received?` are invoked with arguments, they
expect that final arg to be a vector of args, and don't explicitly
handle the non-vector case. Rather than coerce args and perpetuate
the confusion, this change elects to throw an IllegalArgumentException
when the given args aren't in the correct form. Furthermore, it adds
a new test case demonstrate efficacy of `call-count` in that form
against Java base collection classes like `ArrayList`.